### PR TITLE
Fix color role not being removed in /color

### DIFF
--- a/src/commands/roles/Color.ts
+++ b/src/commands/roles/Color.ts
@@ -93,6 +93,7 @@ export default class ColorRolesCommand extends BaseCommand {
 			const role = interaction.guild.roles.cache.get(i.values[0]);
 
 			if (!role) {
+				await i.member.roles.remove(colorRoles.map((colorRole) => colorRole.roleId)).catch(() => { });
 				interaction.followUp({
 					content: "All color roles have been removed from you.",
 					ephemeral: true
@@ -108,7 +109,7 @@ export default class ColorRolesCommand extends BaseCommand {
 				} else {
 					await i.member.roles
 						.remove(colorRoles.map((colorRole) => colorRole.roleId))
-						.catch(() => {});
+						.catch(() => { });
 					await i.member.roles.add(role);
 				}
 


### PR DESCRIPTION
Small fix, originally to remove any color roles you just got via /color, you had to re-run the command as using the same command send a response message acknowledging that roles were supposed to be removed, but didn't actually remove them.