### PR TITLE
Allow /feedback to have multiple channels as feedback channels

### DIFF
--- a/src/commands/configuration/FeedbackChannel.ts
+++ b/src/commands/configuration/FeedbackChannel.ts
@@ -1,0 +1,206 @@
+import { FeedbackChannels } from "@/mongo/schemas/FeedbackChannels";
+import type { DiscordClient } from "@/registry/DiscordClient";
+import BaseCommand, {
+    type DiscordChatInputCommandInteraction
+} from "@/registry/Structure/BaseCommand";
+import { ActionRowBuilder, ButtonBuilder, PermissionFlagsBits, SlashCommandBuilder } from "discord.js";
+import Select from "@/components/Select"
+import { v4 as uuidv4 } from "uuid"
+import Buttons from "@/components/practice/views/Buttons";
+
+export default class FeedbackChannelCommand extends BaseCommand {
+    constructor() {
+        super(
+            new SlashCommandBuilder()
+                .setName("feedback_channel")
+                .setDescription("Modify feedback channel (for mods)")
+                .addSubcommand((subcommand) =>
+                    subcommand
+                        .setName("add")
+                        .setDescription("Add a feedback channel")
+                        .addChannelOption((option) =>
+                            option
+                                .setName("channel")
+                                .setDescription("The channel to send feedback to")
+                                .setRequired(true)
+                        )
+                        .addStringOption((option) =>
+                            option
+                                .setName("team_label")
+                                .setDescription("The team receiving feedback")
+                                .setRequired(true)
+                        )
+                )
+                .addSubcommand((subcommand) =>
+                    subcommand
+                        .setName("remove")
+                        .setDescription("Remove a feedback channel")
+                )
+                .setDMPermission(false)
+                .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild)
+        );
+    }
+
+    async execute(
+        client: DiscordClient<true>,
+        interaction: DiscordChatInputCommandInteraction<"cached">
+    ) {
+
+        switch (interaction.options.getSubcommand()) {
+            case "add": {
+
+                const channel = interaction.options.getChannel("channel", true);
+                const label = interaction.options.getString("team_label", true);
+
+                if (!channel?.isTextBased() || !channel) {
+                    await interaction.reply({
+                        content: "Feedback channel must be a valid text channel.",
+                        ephemeral: true
+                    })
+                    return;
+                }
+
+
+                if (!label) {
+                    await interaction.reply({
+                        content: "Please enter a valid team label.",
+                        ephemeral: true
+                    })
+                    return;
+                }
+
+                await interaction.reply({
+                    content: `Adding feedback channel ${channel} for ${label}`,
+                    ephemeral: true
+                })
+
+                try {
+                    const addChannel = await FeedbackChannels.updateOne(
+                        {
+                            guildId: interaction.guildId,
+                            label: label
+                        },
+                        {
+                            channelId: channel.id
+                        },
+                        { upsert: true }
+                    );
+
+                    addChannel.upsertedCount > 0 ?
+                        await interaction.editReply({
+                            content: `Successfully added ${channel} as the feedback channel for ${label}!`
+                        }) :
+                        addChannel.modifiedCount > 0 ?
+                            await interaction.editReply({
+                                content: `Successfully updated ${channel} as the feedback channel for ${label}`
+                            }) :
+                            await interaction.editReply({
+                                content: `Error occured while creating feedback channel ${channel} for ${label}. Please try again later.`
+                            });
+                } catch (error) {
+                    await interaction.editReply({
+                        content:
+                            `Encountered error while trying to add ${channel} as a feedback channel for ${label}. Please try again later.`
+                    });
+
+                    console.log(error);
+
+                    // client.log(
+                    //     error,
+                    //     `${this.data.name} Command - Add Feedback Channel`,
+                    //     `**Channel:** <#${interaction.channel?.id}>
+                    // 		**User:** <@${interaction.user.id}>
+                    // 		**Guild:** ${interaction.guild.name} (${interaction.guildId})\n`
+                    // );
+                }
+                break;
+            }
+            case "remove": {
+
+                const feedbackTeams = await FeedbackChannels.find({
+                    guildId: interaction.guildId
+                });
+
+                if (feedbackTeams.length == 0) {
+                    await interaction.reply({
+                        content: "There are no feedback channels to be removed",
+                        ephemeral: true
+                    })
+                    return;
+                }
+
+                const customId = uuidv4();
+
+                const teamSelect = new Select(
+                    "team",
+                    "Select a team to stop sending feedback to",
+                    feedbackTeams.map(({ label, channelId, id }) => ({
+                        label: `${label} | #${interaction.guild.channels.cache.get(channelId)?.name}`,
+                        value: id
+                    })),
+                    1,
+                    `${customId}_0`
+                );
+
+                const selectInteraction = await interaction.reply({
+                    content: "Select a team to remove from feedback",
+                    components: [
+                        new ActionRowBuilder<Select>().addComponents(teamSelect),
+                        new Buttons(customId) as ActionRowBuilder<ButtonBuilder>
+                    ],
+                    fetchReply: true,
+                    ephemeral: true
+                });
+
+                const response = await teamSelect.waitForResponse(
+                    `${customId}_0`,
+                    selectInteraction,
+                    interaction,
+                    true
+                );
+
+                if (!response || response === "Timed out" || !response[0]) {
+                    await interaction.followUp({
+                        content: "An error occurred",
+                        ephemeral: false
+                    })
+                    return;
+                }
+
+                const team = await FeedbackChannels.findById(response[0]);
+
+                if (!team) {
+                    await interaction.followUp({
+                        content: "Team not found",
+                        ephemeral: false
+                    })
+                    return;
+                }
+
+                try {
+                    await team.deleteOne();
+                    await interaction.editReply({
+                        content: `Successfully removed feedback for ${team.label}!`,
+                        components: []
+                    });
+                } catch (error) {
+                    await interaction.editReply({
+                        content:
+                            "Encountered error while trying to delete feedback channel. Please try again later."
+                    });
+
+                    client.log(
+                        error,
+                        `${this.data.name} Command - Remove Feedback Channel`,
+                        `**Channel:** <#${interaction.channel?.id}>
+							**User:** <@${interaction.user.id}>
+							**Guild:** ${interaction.guild.name} (${interaction.guildId})\n`
+                    );
+                }
+                break;
+            }
+            default:
+                break;
+        }
+    }
+}

--- a/src/commands/configuration/FeedbackChannel.ts
+++ b/src/commands/configuration/FeedbackChannel.ts
@@ -56,14 +56,13 @@ export default class FeedbackChannelCommand extends BaseCommand {
                     interaction.reply({
                         content: "Feedback channel must be a valid text channel.",
                         ephemeral: true
-                    })
+                    });
                     return;
                 }
 
-                interaction.reply({
-                    content: `Adding feedback channel ${channel} for ${label}`,
+                interaction.deferReply({
                     ephemeral: true
-                })
+                });
 
                 try {
                     const addChannel = await FeedbackChannels.updateOne(
@@ -116,7 +115,7 @@ export default class FeedbackChannelCommand extends BaseCommand {
                     interaction.reply({
                         content: "There are no feedback channels to be removed",
                         ephemeral: true
-                    })
+                    });
                     return;
                 }
 
@@ -154,7 +153,7 @@ export default class FeedbackChannelCommand extends BaseCommand {
                     interaction.followUp({
                         content: "An error occurred",
                         ephemeral: false
-                    })
+                    });
                     return;
                 }
 
@@ -164,7 +163,7 @@ export default class FeedbackChannelCommand extends BaseCommand {
                     interaction.followUp({
                         content: "Team not found",
                         ephemeral: true
-                    })
+                    });
                     return;
                 }
 

--- a/src/commands/miscellaneous/Feedback.ts
+++ b/src/commands/miscellaneous/Feedback.ts
@@ -1,6 +1,7 @@
 import type { DiscordClient } from "@/registry/DiscordClient";
 import {
 	ActionRowBuilder,
+	ButtonBuilder,
 	Colors,
 	EmbedBuilder,
 	ModalBuilder,
@@ -11,16 +12,18 @@ import {
 import BaseCommand, {
 	type DiscordChatInputCommandInteraction
 } from "../../registry/Structure/BaseCommand";
-import { GuildPreferencesCache } from "@/redis";
 import Logger from "@/utils/Logger";
 import { v4 as uuidv4 } from "uuid";
+import { FeedbackChannels } from "@/mongo/schemas/FeedbackChannels";
+import Select from "@/components/Select";
+import Buttons from "@/components/practice/views/Buttons";
 
 export default class FeedbackCommand extends BaseCommand {
 	constructor() {
 		super(
 			new SlashCommandBuilder()
 				.setName("feedback")
-				.setDescription("Send feedback to the server moderators")
+				.setDescription("Submit feedback to the teams behind the server")
 				.setDMPermission(false)
 		);
 	}
@@ -29,14 +32,20 @@ export default class FeedbackCommand extends BaseCommand {
 		client: DiscordClient<true>,
 		interaction: DiscordChatInputCommandInteraction<"cached">
 	) {
-		const guildPreferences = await GuildPreferencesCache.get(
-			interaction.guildId
-		);
 
-		if (!guildPreferences || !guildPreferences.feedbackChannelId) {
+		const feedbackTeams = await FeedbackChannels.find({
+			$or: [{
+				guildId: interaction.guildId
+			}, {
+				label: "Bot Developers",
+				channelId: process.env.DEV_FEEDBACK_CHANNEL_ID
+			}]
+		});
+
+		if (feedbackTeams.length == 0) {
 			await interaction.reply({
 				content:
-					"Please setup the bot using the command `/setup` first.",
+					"Please setup feedback channels using the command `/feedback_channel add` first.",
 				ephemeral: true
 			});
 
@@ -72,7 +81,7 @@ export default class FeedbackCommand extends BaseCommand {
 			modalInteraction.fields.getTextInputValue("feedback-input");
 
 		const embed = new EmbedBuilder()
-			.setTitle(`bois we got some feedback`)
+			.setTitle(`bois we got some feedback rahh`)
 			.setDescription(feedback)
 			.setColor(Colors.Blue)
 			.setAuthor({
@@ -80,13 +89,78 @@ export default class FeedbackCommand extends BaseCommand {
 				iconURL: interaction.user.displayAvatarURL()
 			});
 
-		Logger.channel(interaction.guild, guildPreferences.feedbackChannelId, {
-			embeds: [embed]
-		});
+		const selectCustomId = uuidv4();
 
-		await modalInteraction.reply({
-			content: "Feedback sent!",
+		const teamSelect = new Select(
+			"team",
+			"Select a team to send the feedback to",
+			feedbackTeams.map(({ label, id }) => ({
+				label: `${label}`,
+				value: id
+			})),
+			1,
+			`${selectCustomId}_0`
+		);
+
+		const selectInteraction = await modalInteraction.reply({
+			content: "Feedback acknowledged. Select a team to send feedback to",
+			components: [
+				new ActionRowBuilder<Select>().addComponents(teamSelect),
+				new Buttons(selectCustomId) as ActionRowBuilder<ButtonBuilder>
+			],
+			fetchReply: true,
 			ephemeral: true
 		});
+
+		const response = await teamSelect.waitForResponse(
+			`${selectCustomId}_0`,
+			selectInteraction,
+			interaction,
+			true
+		);
+
+		if (!response || response === "Timed out" || !response[0]) {
+			await interaction.followUp({
+				content: "An error occurred",
+				ephemeral: false
+			})
+			return;
+		}
+
+		const team = await FeedbackChannels.findById(response[0]);
+
+		if (!team) {
+			await interaction.followUp({
+				content: "Team not found",
+				ephemeral: false
+			})
+			return;
+		}
+
+		try {
+			Logger.channel(client.guilds.cache.get(process.env.MAIN_GUILD_ID)!, team.channelId, {
+				embeds: [embed]
+			});
+
+			await modalInteraction.editReply({
+				content: "Feedback sent!",
+				components: []
+			});
+
+		} catch (error) {
+			await interaction.editReply({
+				content:
+					"Encountered error while trying to send feedback. Please try again later."
+			});
+
+			// client.log(
+			// 	error,
+			// 	`${this.data.name} Command - Send Feedback`,
+			// 	`**Channel:** <#${interaction.channel?.id}>
+			// 				**User:** <@${interaction.user.id}>
+			// 				**Guild:** ${interaction.guild.name} (${interaction.guildId})\n`
+			// );
+		}
+
 	}
 }

--- a/src/commands/miscellaneous/Feedback.ts
+++ b/src/commands/miscellaneous/Feedback.ts
@@ -14,7 +14,7 @@ import BaseCommand, {
 } from "../../registry/Structure/BaseCommand";
 import Logger from "@/utils/Logger";
 import { v4 as uuidv4 } from "uuid";
-import { FeedbackChannels } from "@/mongo/schemas/FeedbackChannels";
+import { FeedbackChannels } from "@/mongo/schemas/FeedbackChannel";
 import Select from "@/components/Select";
 import Buttons from "@/components/practice/views/Buttons";
 
@@ -41,16 +41,6 @@ export default class FeedbackCommand extends BaseCommand {
 				channelId: process.env.DEV_FEEDBACK_CHANNEL_ID
 			}]
 		});
-
-		if (feedbackTeams.length == 0) {
-			await interaction.reply({
-				content:
-					"Please setup feedback channels using the command `/feedback_channel add` first.",
-				ephemeral: true
-			});
-
-			return;
-		}
 
 		const feedbackInput = new TextInputBuilder()
 			.setCustomId("feedback-input")
@@ -79,15 +69,6 @@ export default class FeedbackCommand extends BaseCommand {
 
 		const feedback =
 			modalInteraction.fields.getTextInputValue("feedback-input");
-
-		const embed = new EmbedBuilder()
-			.setTitle(`bois we got some feedback rahh`)
-			.setDescription(feedback)
-			.setColor(Colors.Blue)
-			.setAuthor({
-				name: interaction.user.tag,
-				iconURL: interaction.user.displayAvatarURL()
-			});
 
 		const selectCustomId = uuidv4();
 
@@ -137,18 +118,31 @@ export default class FeedbackCommand extends BaseCommand {
 			return;
 		}
 
+		const embed = new EmbedBuilder()
+			.setTitle(`Feedback Received for ${team.label}`)
+			.setDescription(feedback)
+			.setColor(Colors.Blue)
+			.setAuthor({
+				name: interaction.user.tag,
+				iconURL: interaction.user.displayAvatarURL()
+			});
+
+		const mainGuild = client.guilds.cache.get(process.env.MAIN_GUILD_ID);
+
+		if (!mainGuild) return;
+
 		try {
-			Logger.channel(client.guilds.cache.get(process.env.MAIN_GUILD_ID)!, team.channelId, {
+			Logger.channel(mainGuild, team.channelId, {
 				embeds: [embed]
 			});
 
-			await modalInteraction.editReply({
+			modalInteraction.editReply({
 				content: "Feedback sent!",
 				components: []
 			});
 
 		} catch (error) {
-			await interaction.editReply({
+			interaction.editReply({
 				content:
 					"Encountered error while trying to send feedback. Please try again later."
 			});

--- a/src/data.ts
+++ b/src/data.ts
@@ -428,11 +428,6 @@ export const preferences: Preference[] = [
 		key: "studySessionChannelId"
 	},
 	{
-		name: "Feedback Channel",
-		type: "channel",
-		key: "feedbackChannelId"
-	},
-	{
 		name: "Modmail Create New DM Channel",
 		type: "channel",
 		key: "modmailCreateChannelId"

--- a/src/data.ts
+++ b/src/data.ts
@@ -18,11 +18,14 @@ export const ywAliases = [
 	"شكر على واجب",//  Arabic
 	"bitte", // German
 	"kein problem", // German
+	"gern geschehen", // German
 	"不用客气", // Mandarin Chinese
 	"不用谢", // Mandarin Chinese
+	"不客气", // Mandarin Chinese
 	"bu yong", // Mandarin Chinese
 	"کوئی بات نہیں",//  Urdu
 	"مسئلہ نہیں", //  Urdu
+	"مَسْلَہ",//  Urdu
 	"koi baat nahi", // Urdu/Hindi
 	"masla nahi", // Urdu/Hindi
 	"कोई बात नहीं", // Hindi
@@ -52,9 +55,12 @@ export const tyAliases = [
 	"remerci", // French
 	"谢", // Mandarin Chinese
 	"谢谢", // Mandarin Chinese
+	"感谢", // Mandarin Chinese
+	"感恩", // Mandarin Chinese
 	"谢啦", // Mandarin Chinese
 	"谢了", // Mandarin Chinese
 	"谢过", // Mandarin Chinese
+	"没关系", // Mandarin Chinese
 	"xiexie", // Mandarin Chinese
 	"danke", // German
 	"vielen dank", // German
@@ -62,8 +68,8 @@ export const tyAliases = [
 	"shukriya", // Urdu/Hindi
 	"shukrya", // Urdu/Hindi
 	"shukria", // Urdu/Hindi
-	"dhanyewaat", // Hindi
-	"dhanyevaat",
+	"dhanyewaad", // Hindi
+	"dhanyevaad", // Hindi
 	"धन्येवात", // Hindi
 
 ];

--- a/src/mongo/schemas/FeedbackChannel.ts
+++ b/src/mongo/schemas/FeedbackChannel.ts
@@ -1,17 +1,15 @@
 import { Schema, model as createModel } from "mongoose";
 
-export interface IFeedbackChannels {
+export interface IFeedbackChannel {
     guildId: string;
     label: string;
     channelId: string;
 }
 
-const schema = new Schema<IFeedbackChannels>({
+const schema = new Schema<IFeedbackChannel>({
     guildId: { type: String, required: true, unique: false },
     label: { type: String, required: true, unique: false },
     channelId: { type: String, required: true, unique: false }
 });
 
-schema.index({ guildId: 1, label: 1 }, { unique: true });
-
-export const FeedbackChannels = createModel<IFeedbackChannels>("FeedbackChannels", schema);
+export const FeedbackChannels = createModel<IFeedbackChannel>("FeedbackChannel", schema);

--- a/src/mongo/schemas/FeedbackChannels.ts
+++ b/src/mongo/schemas/FeedbackChannels.ts
@@ -1,0 +1,17 @@
+import { Schema, model as createModel } from "mongoose";
+
+export interface IFeedbackChannels {
+    guildId: string;
+    label: string;
+    channelId: string;
+}
+
+const schema = new Schema<IFeedbackChannels>({
+    guildId: { type: String, required: true, unique: false },
+    label: { type: String, required: true, unique: false },
+    channelId: { type: String, required: true, unique: false }
+});
+
+schema.index({ guildId: 1, label: 1 }, { unique: true });
+
+export const FeedbackChannels = createModel<IFeedbackChannels>("FeedbackChannels", schema);

--- a/src/mongo/schemas/GuildPreferences.ts
+++ b/src/mongo/schemas/GuildPreferences.ts
@@ -17,7 +17,6 @@ export type IGuildPreferences = {
 	hotmResultsChannelId: string;
 	hotmResultsEmbedId: string;
 	studySessionChannelId: string;
-	feedbackChannelId: string;
 
 	modmailCreateChannelId: string;
 	modmailThreadsChannelId: string;
@@ -45,7 +44,6 @@ const schema = new Schema<IGuildPreferences>({
 	hotmResultsChannelId: { type: String, default: null },
 	hotmResultsEmbedId: { type: String, default: null },
 	studySessionChannelId: { type: String, default: null },
-	feedbackChannelId: { type: String, default: null },
 	modmailCreateChannelId: { type: String, default: null },
 	modmailThreadsChannelId: { type: String, default: null },
 	modmailLogsChannelId: { type: String, default: null },

--- a/src/redis/schemas/GuildPreferences.ts
+++ b/src/redis/schemas/GuildPreferences.ts
@@ -22,7 +22,6 @@ const schema = new Schema("GuildPreferences", {
 	hotmResultsChannelId: { type: "string" },
 	hotmResultsEmbedId: { type: "string" },
 	studySessionChannelId: { type: "string" },
-	feedbackChannelId: { type: "string" },
 	modmailCreateChannelId: { type: "string" },
 	modmailThreadsChannelId: { type: "string" },
 	modmailLogsChannelId: { type: "string" },


### PR DESCRIPTION
- Added database for feedback channels `FeedbackChannels`
- Added command `/feedback add/remove` to add/remove feedback channels for different teams
- Removed `feedbackChannelId` from `/setup`
- Sending feedback to `Bot Developers` will send the feedback to `#feedback` in main guild
- Added some more aliases for ty/nw