### PR TITLE
feat: /feedback: show guild name in bot developer feedback

### DIFF
--- a/src/commands/configuration/FeedbackChannel.ts
+++ b/src/commands/configuration/FeedbackChannel.ts
@@ -60,7 +60,15 @@ export default class FeedbackChannelCommand extends BaseCommand {
                     return;
                 }
 
-                interaction.deferReply({
+                if (label === "Bot Developers") {
+                    interaction.reply({
+                        content: "Label cannot be `Bot Developers`",
+                        ephemeral: true
+                    })
+                    return;
+                }
+
+                await interaction.deferReply({
                     ephemeral: true
                 });
 


### PR DESCRIPTION
- Disallowed having `Bot Developers` as a label
- Changed value of string select items to `label` instead of `channelId`
- Feedback messages will now display the guild they were sent from **if** they were sent to `Bot Developers` 