### PR TITLE
feat: /feedback: moved server name/id to embed footer

### DIFF
--- a/src/commands/HOTM/VotingSession.ts
+++ b/src/commands/HOTM/VotingSession.ts
@@ -91,7 +91,8 @@ export default class HOTMSessionCommand extends BaseCommand {
 		if (!guildPreferences) {
 			interaction.reply({
 				content:
-					"Configure the bot using `/setup` before starting sessions"
+					"Configure the bot using `/setup` before starting sessions",
+				ephemeral: true
 			});
 			return;
 		}
@@ -234,11 +235,11 @@ export default class HOTMSessionCommand extends BaseCommand {
 	async endSession(client: DiscordClient<true>, guildId?: string | null) {
 		const sessions = guildId
 			? await HOTMSession.find({
-					guildId
-				})
+				guildId
+			})
 			: await HOTMSession.find({
-					endDate: { $gte: Date.now() }
-				});
+				endDate: { $gte: Date.now() }
+			});
 		if (!sessions) return;
 
 		for (const session of sessions) {
@@ -299,7 +300,7 @@ export default class HOTMSessionCommand extends BaseCommand {
 			.addFields(...fields);
 
 		if (messageId)
-			resultsChannel.messages.delete(messageId).catch(() => {});
+			resultsChannel.messages.delete(messageId).catch(() => { });
 
 		const embedMessage = await resultsChannel.send({
 			embeds: [embed]

--- a/src/commands/miscellaneous/Feedback.ts
+++ b/src/commands/miscellaneous/Feedback.ts
@@ -129,21 +129,34 @@ export default class FeedbackCommand extends BaseCommand {
 
 		if (!messageGuild) return;
 
-		const feedbackGuildMessage =
-			team?.label === "Bot Developers"
-				? ` from ${feedbackGuild?.name} (${feedbackGuild?.id})`
-				: "";
+		let embed;
 
-		const embed = new EmbedBuilder()
-			.setTitle(
-				`Feedback received${feedbackGuildMessage} for ${team.label}`
-			)
-			.setDescription(feedback)
-			.setColor(Colors.Blue)
-			.setAuthor({
-				name: interaction.user.tag,
-				iconURL: interaction.user.displayAvatarURL()
-			});
+		if (team?.label === "Bot Developers") {
+			embed = new EmbedBuilder()
+				.setTitle(
+					`Bot Feedback Received`
+				)
+				.setDescription(feedback)
+				.setFooter({
+					text: `from ${feedbackGuild.name} (${feedbackGuild.id})`
+				})
+				.setColor(Colors.Blue)
+				.setAuthor({
+					name: interaction.user.tag,
+					iconURL: interaction.user.displayAvatarURL()
+				});
+		} else {
+			embed = new EmbedBuilder()
+				.setTitle(
+					`Feedback received for ${team.label}`
+				)
+				.setDescription(feedback)
+				.setColor(Colors.Blue)
+				.setAuthor({
+					name: interaction.user.tag,
+					iconURL: interaction.user.displayAvatarURL()
+				});
+		}
 
 		try {
 			Logger.channel(messageGuild, team.channelId, {


### PR DESCRIPTION
Server name and ID will now be shown in the embed's footer instead of header
(also fixed config message in /hotm_session not being ephemeral)