### PR TITLE
fix: remove nw as alias for your welcome

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -3,6 +3,7 @@ import { type IGuildPreferences } from "@/mongo";
 export const ywAliases = [
 	"you're welcome",
 	"your welcome",
+	"youre welcome",
 	"ur welcome",
 	"yw",
 	"no problem",

--- a/src/data.ts
+++ b/src/data.ts
@@ -2,12 +2,11 @@ import { type IGuildPreferences } from "@/mongo";
 
 export const ywAliases = [
 	"you're welcome",
+	"your welcome",
 	"ur welcome",
 	"yw",
 	"no problem",
 	"np",
-	"nws",
-	"nw",
 	"sama sama", // Malay
 	"derien", // French
 	"de rien", // French


### PR DESCRIPTION
- Removed nw/nws as an alias for you're welcome
- Added "your welcome" as an alias for you're welcome