### PR TITLE
Fix sticky pins

### DIFF
--- a/src/commands/menus/StickyPin.ts
+++ b/src/commands/menus/StickyPin.ts
@@ -4,8 +4,11 @@ import BaseCommand, {
 	type DiscordMessageContextMenuCommandInteraction,
 } from "@/registry/Structure/BaseCommand";
 import {
+	ActionRowBuilder,
 	type AnyThreadChannel,
 	ApplicationCommandType,
+	ButtonBuilder,
+	ButtonStyle,
 	ContextMenuCommandBuilder,
 	EmbedBuilder,
 	PermissionFlagsBits,
@@ -31,27 +34,91 @@ export default class StickMessageCommand extends BaseCommand {
 		const oldRes = await StickyPinnedMessage.findOne({
 			channelId: interaction.channel.id,
 		});
-
+		
 		if (oldRes) {
-			interaction.reply({
-				content: `This channel already has a sticky pinned message: https://discord.com/channels/${interaction.guildId}/${oldRes.channelId}/${oldRes.messageId}`,
-				ephemeral: true,
-			});
+			const yesButton = new ButtonBuilder()
+							.setCustomId("yes")
+							.setLabel("Yes")
+							.setStyle(ButtonStyle.Success);
+			const noButton = new ButtonBuilder()
+				.setCustomId("no")
+				.setLabel("No")
+				.setStyle(ButtonStyle.Danger);
 
-			return;
+			if (oldRes.messageId !== interaction.targetMessage.id) {
+				const response = await interaction.reply({
+					content: `Override old sticky pin? https://discord.com/channels/${interaction.guildId}/${oldRes.channelId}/${oldRes.messageId}`,
+					components: [
+						new ActionRowBuilder<ButtonBuilder>().addComponents(
+							yesButton,
+							noButton,
+						),
+					],
+					ephemeral: true,
+				});
+
+				const confirmation = await response.awaitMessageComponent({
+					time: 60_000,
+				});
+
+				if (confirmation.customId === "no") {
+					await confirmation.update({
+						content: "Cancelled.",
+						components: [],
+					});
+					return;
+				} else if (confirmation.customId === "yes") {
+					await interaction.deleteReply();
+				}
+			} else {
+				const response = await interaction.reply({
+					content: `This message is already sticky pinned. Would you like to remove it as a sticky pin (while still keeping it as a regular pin)?`,
+					components: [
+						new ActionRowBuilder<ButtonBuilder>().addComponents(
+							yesButton,
+							noButton,
+						),
+					],
+					ephemeral: true,
+				});
+
+				const confirmation = await response.awaitMessageComponent({
+					time: 60_000,
+				});
+
+				if (confirmation.customId === "no") {
+					await confirmation.update({
+						content: "Cancelled.",
+						components: [],
+					});
+				} else if (confirmation.customId === "yes") {
+					await oldRes.deleteOne();
+					await confirmation.update({
+						content: "This is no longer a sticky pin.",
+						components: [],
+					});
+				}
+				return;
+			}
 		}
 
-		const res = await StickyPinnedMessage.create({
-			channelId: interaction.channel.id,
-			messageId: interaction.targetMessage.id,
-		});
+		const res = await StickyPinnedMessage.updateOne(
+			{
+			  channelId: interaction.channel.id,
+			},
+			{
+			  $set: {
+				messageId: interaction.targetMessage.id,
+			  },
+			},
+			{ upsert: true }
+		  );
 
 		if (!res) {
 			interaction.followUp({
 				content: "Failed to create sticky pinned message.",
 				ephemeral: true,
 			});
-
 			return;
 		}
 
@@ -64,8 +131,7 @@ export default class StickMessageCommand extends BaseCommand {
 				content: `Messaged sticky pinned by ${interaction.user}`,
 			});
 		} catch (error) {
-			res.deleteOne();
-
+			await StickyPinnedMessage.deleteOne({ channelId: interaction.channel.id });
 			const pinnedMessages = (
 				await interaction.channel.messages.fetchPinned()
 			).sort((a, b) => a.createdTimestamp - b.createdTimestamp);
@@ -140,10 +206,5 @@ export default class StickMessageCommand extends BaseCommand {
 					**Guild:** ${interaction.guild.name} (${interaction.guildId})\n`,
 			);
 		}
-
-		interaction.reply({
-			content: "Successfully sticky pinned message.",
-			ephemeral: true,
-		});
 	}
 }


### PR DESCRIPTION
1. Sticky pins get re-pinned after a new pin so it remains on top
2. Sticky pins can now be un-stickied or replace with another pin instead
3. Removed some unused code

(now with new branch and updated db storing)