### PR TITLE
hotfix: resource tag expiration

### DIFF
--- a/src/commands/menus/RequestResourceTag.ts
+++ b/src/commands/menus/RequestResourceTag.ts
@@ -206,7 +206,7 @@ export default class StickMessageCommand extends BaseCommand {
 
 		await ButtonInteractionCache.expire(
 			`${customId}_tag`,
-			3 * 24 * 60 * 60,
+			14 * 24 * 60 * 60,
 		);
 	}
 }


### PR DESCRIPTION
Changed button cache expiration to 14 days for helpers to approve/reject