### PR TITLE
feat: mass sticky

### DIFF
--- a/src/commands/menus/ToggleSticky.ts
+++ b/src/commands/menus/ToggleSticky.ts
@@ -1,214 +1,330 @@
 import { StickyMessage } from "@/mongo";
 import { StickyMessageCache } from "@/redis";
 import type {
-	APIEmbedRedis,
-	ICachedStickyMessage,
+  APIEmbedRedis,
+  ICachedStickyMessage,
 } from "@/redis/schemas/StickyMessage";
 import type { DiscordClient } from "@/registry/DiscordClient";
 import BaseCommand, {
-	type DiscordMessageContextMenuCommandInteraction,
+  type DiscordMessageContextMenuCommandInteraction,
 } from "@/registry/Structure/BaseCommand";
 import {
-	ActionRowBuilder,
-	ApplicationCommandType,
-	ChannelSelectMenuBuilder,
-	ChannelType,
-	ComponentType,
-	ContextMenuCommandBuilder,
-	ModalBuilder,
-	PermissionFlagsBits,
-	TextInputBuilder,
-	MessageFlags,
-	TextInputStyle,
+  ActionRowBuilder,
+  ApplicationCommandType,
+  ChannelSelectMenuBuilder,
+  ChannelType,
+  ComponentType,
+  ContextMenuCommandBuilder,
+  ModalBuilder,
+  PermissionFlagsBits,
+  TextInputBuilder,
+  MessageFlags,
+  TextInputStyle,
 } from "discord.js";
 import { EntityId } from "redis-om";
 
 export default class StickMessageCommand extends BaseCommand {
-	constructor() {
-		super(
-			new ContextMenuCommandBuilder()
-				.setName("Toggle Sticky Message")
-				.setDefaultMemberPermissions(PermissionFlagsBits.ManageMessages)
-				.setDMPermission(false)
-				.setType(ApplicationCommandType.Message),
-		);
-	}
+  constructor() {
+    super(
+      new ContextMenuCommandBuilder()
+        .setName("Toggle Sticky Message")
+        .setDefaultMemberPermissions(PermissionFlagsBits.ManageMessages)
+        .setDMPermission(false)
+        .setType(ApplicationCommandType.Message)
+    );
+  }
 
-	async execute(
-		client: DiscordClient<true>,
-		interaction: DiscordMessageContextMenuCommandInteraction<"cached">,
-	) {
-		if (!interaction.channel) return;
+  async execute(
+    client: DiscordClient<true>,
+    interaction: DiscordMessageContextMenuCommandInteraction<"cached">
+  ) {
+    if (!interaction.channel) return;
 
-		const stickyCheck = (await StickyMessageCache.search()
-			.where("messageId")
-			.equals(interaction.targetId)
-			.returnAll()) as ICachedStickyMessage[];
+    const stickyCheck = (await StickyMessageCache.search()
+      .where("messageId")
+      .equals(interaction.targetId)
+      .returnAll()) as ICachedStickyMessage[];
 
-		console.log(stickyCheck);
+    console.log(stickyCheck);
 
-		if (
-			!stickyCheck ||
-			stickyCheck.length < 1 ||
-			!stickyCheck[0][EntityId]
-		) {
-			const time = Date.now();
-			const stickTimeInput = new TextInputBuilder()
-				.setCustomId("stick-time")
-				.setLabel("Stick Time")
-				.setStyle(TextInputStyle.Short)
-				.setPlaceholder(time.toString())
-				.setRequired(false);
-			const unstickTimeInput = new TextInputBuilder()
-				.setCustomId("unstick-time")
-				.setLabel("Unstick Time")
-				.setStyle(TextInputStyle.Short)
-				.setPlaceholder((time + 2592000).toString())
-				.setRequired(false);
+    if (!stickyCheck || stickyCheck.length < 1 || !stickyCheck[0][EntityId]) {
+      const time = Date.now();
+      const stickTimeInput = new TextInputBuilder()
+        .setCustomId("stick-time")
+        .setLabel("Stick Time")
+        .setStyle(TextInputStyle.Short)
+        .setPlaceholder(time.toString())
+        .setRequired(false);
+      const unstickTimeInput = new TextInputBuilder()
+        .setCustomId("unstick-time")
+        .setLabel("Unstick Time")
+        .setStyle(TextInputStyle.Short)
+        .setPlaceholder((time + 2592000).toString())
+        .setRequired(false);
+      const categoryIdsInput = new TextInputBuilder()
+        .setCustomId("category-ids")
+        .setLabel("Category IDs (will stick in all channels)")
+        .setStyle(TextInputStyle.Short)
+        .setPlaceholder("Comma Separated")
+        .setRequired(false);
 
-			const row1 = new ActionRowBuilder<TextInputBuilder>().addComponents(
-				stickTimeInput,
-			);
-			const row2 = new ActionRowBuilder<TextInputBuilder>().addComponents(
-				unstickTimeInput,
-			);
+      const row1 = new ActionRowBuilder<TextInputBuilder>().addComponents(
+        stickTimeInput
+      );
+      const row2 = new ActionRowBuilder<TextInputBuilder>().addComponents(
+        unstickTimeInput
+      );
+      const row3 = new ActionRowBuilder<TextInputBuilder>().addComponents(
+        categoryIdsInput
+      );
 
-			const modal = new ModalBuilder()
-				.setTitle("Stick Message (Times are optional)")
-				.setCustomId("stick-message")
-				.addComponents(row1, row2);
-			await interaction.showModal(modal);
+      const modal = new ModalBuilder()
+        .setTitle("Stick Message (Times are optional)")
+        .setCustomId("stick-message")
+        .addComponents(row1, row2, row3);
+      await interaction.showModal(modal);
 
-			const modalInteraction = await interaction.awaitModalSubmit({
-				filter: (i) =>
-					i.user.id === interaction.user.id &&
-					i.customId === "stick-message",
-				time: 90000,
-			});
+      const modalInteraction = await interaction.awaitModalSubmit({
+        filter: (i) =>
+          i.user.id === interaction.user.id && i.customId === "stick-message",
+        time: 90000,
+      });
 
-			await modalInteraction.deferUpdate();
+      await modalInteraction.deferUpdate();
 
-			const stickTime =
-				Number.parseInt(
-					modalInteraction.fields.getTextInputValue("stick-time"),
-				) || null;
-			const unstickTime =
-				Number.parseInt(
-					modalInteraction.fields.getTextInputValue("unstick-time"),
-				) || null;
+      const stickTime =
+        Number.parseInt(
+          modalInteraction.fields.getTextInputValue("stick-time")
+        ) || null;
+      const unstickTime =
+        Number.parseInt(
+          modalInteraction.fields.getTextInputValue("unstick-time")
+        ) || null;
+      const categoryIds =
+        modalInteraction.fields.getTextInputValue("category-ids");
 
-			if (stickTime && unstickTime) {
-				if (stickTime > unstickTime) {
-					await interaction.followUp({
-						content: "Stick time must be before unstick time.",
-						flags: MessageFlags.Ephemeral,
-					});
+      if (stickTime && unstickTime) {
+        if (stickTime > unstickTime) {
+          await interaction.followUp({
+            content: "Stick time must be before unstick time.",
+            flags: MessageFlags.Ephemeral,
+          });
 
-					return;
-				}
-				if (unstickTime < time) {
-					await interaction.followUp({
-						content: "Unstick time must be after now.",
-						flags: MessageFlags.Ephemeral,
-					});
+          return;
+        }
+        if (unstickTime < time) {
+          await interaction.followUp({
+            content: "Unstick time must be after now.",
+            flags: MessageFlags.Ephemeral,
+          });
 
-					return;
-				}
-			}
+          return;
+        }
+      }
 
-			const channelSelect = new ChannelSelectMenuBuilder()
-				.setCustomId("stick-channel")
-				.setPlaceholder("Select a channel")
-				.setMaxValues(1)
-				.setMinValues(1)
-				.setChannelTypes(
-					ChannelType.GuildText,
-					ChannelType.PublicThread,
-					ChannelType.PrivateThread,
-					ChannelType.GuildStageVoice,
-				);
+      if (!categoryIds) {
+        const channelSelect = new ChannelSelectMenuBuilder()
+          .setCustomId("stick-channel")
+          .setPlaceholder("Select a channel")
+          .setMaxValues(1)
+          .setMinValues(1)
+          .setChannelTypes(
+            ChannelType.GuildText,
+            ChannelType.PublicThread,
+            ChannelType.PrivateThread,
+            ChannelType.GuildStageVoice
+          );
 
-			const channelRow =
-				new ActionRowBuilder<ChannelSelectMenuBuilder>().addComponents(
-					channelSelect,
-				);
+        const channelRow =
+          new ActionRowBuilder<ChannelSelectMenuBuilder>().addComponents(
+            channelSelect
+          );
 
-			const interactionRes = await interaction.followUp({
-				components: [channelRow],
-				flags: MessageFlags.Ephemeral,
-			});
+        const interactionRes = await interaction.followUp({
+          components: [channelRow],
+          flags: MessageFlags.Ephemeral,
+        });
 
-			const selectInteraction =
-				await interactionRes.awaitMessageComponent({
-					componentType: ComponentType.ChannelSelect,
-					filter: (i) =>
-						i.user.id === interaction.user.id &&
-						i.customId === "stick-channel",
-					time: 60000,
-				});
+        const selectInteraction = await interactionRes.awaitMessageComponent({
+          componentType: ComponentType.ChannelSelect,
+          filter: (i) =>
+            i.user.id === interaction.user.id && i.customId === "stick-channel",
+          time: 60000,
+        });
 
-			await selectInteraction.deferUpdate();
+        await selectInteraction.deferUpdate();
 
-			const channelId = selectInteraction.values[0];
-			const channel = interaction.guild.channels.cache.get(channelId);
-			if (!channel || !channel.isTextBased()) {
-				await interaction.followUp({
-					content: "Channel not found / Invalid channel type",
-					flags: MessageFlags.Ephemeral,
-				});
+        const channelId = selectInteraction.values[0];
+        const channel = interaction.guild.channels.cache.get(channelId);
+        if (!channel || !channel.isTextBased()) {
+          await interaction.followUp({
+            content: "Channel not found / Invalid channel type",
+            flags: MessageFlags.Ephemeral,
+          });
 
-				return;
-			}
+          return;
+        }
 
-			const res = await StickyMessage.create({
-				channelId: channel.id,
-				messageId: null,
-				message: {
-					content: interaction.targetMessage.content,
-					embeds: interaction.targetMessage.embeds.map((embed) =>
-						embed.toJSON(),
-					),
-				},
-				stickTime: stickTime?.toString(),
-				unstickTime: unstickTime?.toString(),
-			});
+        const res = await StickyMessage.create({
+          channelId: channel.id,
+          messageId: null,
+          message: {
+            content: interaction.targetMessage.content,
+            embeds: interaction.targetMessage.embeds.map((embed) =>
+              embed.toJSON()
+            ),
+          },
+          stickTime: stickTime?.toString(),
+          unstickTime: unstickTime?.toString(),
+        });
 
-			if (!res) {
-				await interaction.followUp({
-					content: "Failed to create sticky message.",
-					flags: MessageFlags.Ephemeral,
-				});
+        if (!res) {
+          await interaction.followUp({
+            content: "Failed to create sticky message.",
+            flags: MessageFlags.Ephemeral,
+          });
 
-				return;
-			}
+          return;
+        }
 
-			if (!unstickTime && !stickTime) {
-				await StickyMessageCache.set(res.id, {
-					channelId: channel.id,
-					messageId: null,
-					message: {
-						content: interaction.targetMessage.content,
-						embeds: interaction.targetMessage.embeds.map((embed) =>
-							embed.toJSON(),
-						) as APIEmbedRedis[],
-					},
-				});
+        if (!unstickTime && !stickTime) {
+          await StickyMessageCache.set(res.id, {
+            channelId: channel.id,
+            messageId: null,
+            message: {
+              content: interaction.targetMessage.content,
+              embeds: interaction.targetMessage.embeds.map((embed) =>
+                embed.toJSON()
+              ) as APIEmbedRedis[],
+            },
+          });
 
-				client.stickyChannelIds.push(channel.id);
-			}
+          client.stickyChannelIds.push(channel.id);
+        }
 
-			await interaction.followUp({
-				content: "Message scheduled to stick.",
-				flags: MessageFlags.Ephemeral,
-			});
-		} else {
-			await StickyMessageCache.remove(stickyCheck[0][EntityId]);
-			await StickyMessage.deleteOne({ _id: stickyCheck[0][EntityId] });
+        await interaction.followUp({
+          content: "Message scheduled to stick.",
+          flags: MessageFlags.Ephemeral,
+        });
+      } else {
+        const categoryChannelIDs = categoryIds
+          .split(",")
+          .map((id) => id.trim());
 
-			await interaction.reply({
-				content: "Successfully unstuck message.",
-				flags: MessageFlags.Ephemeral,
-			});
-		}
-	}
+        const categoryChannels = categoryChannelIDs.map(
+          (id) => interaction.guild.channels.cache.get(id) ?? id
+        );
+
+        if (categoryChannels.length < 1) {
+          await interaction.followUp({
+            content: "Invalid category channels, message not stickied.",
+            flags: MessageFlags.Ephemeral,
+          });
+
+          return;
+        }
+
+        for (const categoryChannel of categoryChannels) {
+          if (
+            !categoryChannel ||
+            typeof categoryChannel === "string" ||
+            categoryChannel.type !== ChannelType.GuildCategory
+          ) {
+            interaction.followUp({
+              content: `${categoryChannel} is not a valid category channel.`,
+              flags: MessageFlags.Ephemeral,
+            });
+            continue;
+          }
+
+          const stickyChannels = categoryChannel.children.cache.filter((c) =>
+            c.isTextBased()
+          );
+
+          if (stickyChannels.size < 1) {
+            await interaction.followUp({
+              content:
+                "No valid text channels found in category, message not stickied.",
+              flags: MessageFlags.Ephemeral,
+            });
+
+            return;
+          }
+
+          if (!unstickTime && !stickTime) {
+            for (const [, channel] of stickyChannels) {
+              const res = await StickyMessage.create({
+                channelId: channel.id,
+                messageId: null,
+                message: {
+                  content: interaction.targetMessage.content,
+                  embeds: interaction.targetMessage.embeds.map((embed) =>
+                    embed.toJSON()
+                  ),
+                },
+                stickTime: stickTime?.toString(),
+                unstickTime: unstickTime?.toString(),
+              });
+
+              if (!res) {
+                await interaction.followUp({
+                  content: `Failed to create sticky message in ${channel}.`,
+                  flags: MessageFlags.Ephemeral,
+                });
+
+                continue;
+              }
+              await StickyMessageCache.set(res.id, {
+                channelId: channel.id,
+                messageId: null,
+                message: {
+                  content: interaction.targetMessage.content,
+                  embeds: interaction.targetMessage.embeds.map((embed) =>
+                    embed.toJSON()
+                  ) as APIEmbedRedis[],
+                },
+              });
+
+              client.stickyChannelIds.push(channel.id);
+            }
+          } else {
+            for (const [, channel] of stickyChannels) {
+              const res = await StickyMessage.create({
+                channelId: channel.id,
+                messageId: null,
+                message: {
+                  content: interaction.targetMessage.content,
+                  embeds: interaction.targetMessage.embeds.map((embed) =>
+                    embed.toJSON()
+                  ),
+                },
+                stickTime: stickTime?.toString(),
+                unstickTime: unstickTime?.toString(),
+              });
+
+              if (!res) {
+                await interaction.followUp({
+                  content: `Failed to create sticky message in ${channel}.`,
+                  flags: MessageFlags.Ephemeral,
+                });
+              }
+            }
+          }
+
+          await interaction.followUp({
+            content: `Message stickied in all text channels in ${categoryChannel}.`,
+            flags: MessageFlags.Ephemeral,
+          });
+        }
+      }
+    } else {
+      await StickyMessageCache.remove(stickyCheck[0][EntityId]);
+      await StickyMessage.deleteOne({ _id: stickyCheck[0][EntityId] });
+
+      await interaction.reply({
+        content: "Successfully unstuck message.",
+        flags: MessageFlags.Ephemeral,
+      });
+    }
+  }
 }

--- a/src/commands/moderation/MassRemoveSticky.ts
+++ b/src/commands/moderation/MassRemoveSticky.ts
@@ -1,0 +1,105 @@
+import { StickyMessage } from "@/mongo";
+import { StickyMessageCache, GuildPreferencesCache } from "@/redis";
+import type { ICachedStickyMessage } from "@/redis/schemas/StickyMessage";
+import type { DiscordClient } from "@/registry/DiscordClient";
+import BaseCommand, {
+  type DiscordChatInputCommandInteraction,
+} from "@/registry/Structure/BaseCommand";
+import { logToChannel } from "@/utils/Logger";
+import {
+  Colors,
+  EmbedBuilder,
+  PermissionFlagsBits,
+  SlashCommandBuilder,
+  MessageFlags,
+  ChannelType,
+} from "discord.js";
+
+export default class KickCommand extends BaseCommand {
+  constructor() {
+    super(
+      new SlashCommandBuilder()
+        .setName("mass_remove_sticky")
+        .setDescription(
+          "Remove sticky messages from all channels in a category (for mods)"
+        )
+        .addStringOption((option) =>
+          option
+            .setName("category_id")
+            .setDescription("ID of the category to remove sticky messages from")
+            .setRequired(true)
+        )
+        .setDefaultMemberPermissions(PermissionFlagsBits.ManageMessages)
+        .setDMPermission(false)
+    );
+  }
+
+  async execute(
+    client: DiscordClient<true>,
+    interaction: DiscordChatInputCommandInteraction<"cached">
+  ) {
+    if (!interaction.channel || !interaction.channel.isTextBased()) return;
+
+    await interaction.deferReply({
+      flags: MessageFlags.Ephemeral,
+    });
+
+    const categoryId = interaction.options.getString("category_id", true);
+    const categoryChannel = interaction.guild.channels.cache.get(categoryId);
+
+    if (
+      !categoryChannel ||
+      categoryChannel.type !== ChannelType.GuildCategory
+    ) {
+      interaction.editReply({
+        content: "ID provided is not a valid category channel",
+      });
+      return;
+    }
+
+    const stickyChannels = categoryChannel?.children.cache.filter((c) =>
+      c.isTextBased()
+    );
+
+    for (const [, channel] of stickyChannels) {
+      const stickyMessages = await StickyMessageCache.search()
+        .where("channelId")
+        .equals(channel.id)
+        .return.allIds();
+
+      if (stickyMessages) {
+        await StickyMessageCache.remove(...stickyMessages);
+        await StickyMessage.deleteMany({
+          channelId: channel.id,
+        });
+      }
+    }
+
+    const guildPreferences = await GuildPreferencesCache.get(
+      interaction.guildId
+    );
+
+    if (guildPreferences?.generalLogsChannelId) {
+      logToChannel(interaction.guild, guildPreferences.generalLogsChannelId, {
+        embeds: [
+          new EmbedBuilder()
+            .setTitle("Messages Unstickied")
+            .setDescription(
+              `All messages in <#${categoryId}> unstickied by ${interaction.user.tag} (${interaction.user.id})`
+            )
+            .setColor("Green")
+            .setTimestamp(),
+        ],
+      }).catch(() => {
+        interaction.followUp({
+          content: "Invalid log channel, contact admins",
+          flags: MessageFlags.Ephemeral,
+        });
+      });
+    }
+
+    interaction.editReply({
+      content: `Unstickied all messages in <#${categoryId}>`,
+    });
+  }
+}

--- a/src/commands/moderation/ResetNickname.ts
+++ b/src/commands/moderation/ResetNickname.ts
@@ -50,6 +50,17 @@ export default class KickCommand extends BaseCommand {
     const user = interaction.options.getUser("user", true);
     const reason = interaction.options.getString("reason", false) ?? null;
 
+    const displayName = interaction.guild.members.cache.get(
+      user.id
+    )?.displayName;
+
+    if (!displayName) {
+      interaction.editReply({
+        content: "User not found in this server.",
+      });
+      return;
+    }
+
     if (user.id === interaction.user.id) {
       interaction.editReply({
         content: "You cannot reset your own display name.",
@@ -78,9 +89,9 @@ export default class KickCommand extends BaseCommand {
     const dmEmbed = new EmbedBuilder()
       .setTitle("Nickname Reset")
       .setDescription(
-        `You must rename yourself in **${interaction.guild.name}**${
-          reason ? ` due to \`${reason}\`.` : "."
-        }`
+        `Your nickname \`${displayName}\` must be renamed in **${
+          interaction.guild.name
+        }**${reason ? ` due to \`${reason}\`.` : "."}`
       )
       .setColor(Colors.Red);
 
@@ -151,7 +162,9 @@ export default class KickCommand extends BaseCommand {
           },
           {
             name: "Reason",
-            value: reason ?? "No reason provided",
+            value: `${
+              reason ?? "No reason provided"
+            } (previous nickname: ${displayName})`,
           },
         ])
         .setTimestamp();


### PR DESCRIPTION
- Added category channel IDs option to sticky message
- All categories entered (separated by commas) have the message stickied
- `/mass_sticky_remove` will remove all sticky messages for all channels within the category provided
- Added names to name reset DM/log