### PR TITLE
Improve lockdown scheduling reply messages

### DIFF
--- a/src/commands/moderation/Lockdown.ts
+++ b/src/commands/moderation/Lockdown.ts
@@ -325,9 +325,12 @@ export default class LockdownCommand extends BaseCommand {
 					);
 
 					await interaction.editReply({
-						content: `<#${channel.id}> will be locked at <t:${lockTime}:F> (<t:${lockTime}:R>) and will be unlocked at <t:${unlockTime}:F> (<t:${unlockTime}:R>)`,
+						content: `<#${channel.id}> has been locked immediately and will be unlocked at <t:${unlockTime}:F> (<t:${unlockTime}:R>)`,
 					});
-					break;
+				} else {
+					await interaction.editReply({
+						content: `<#${channel.id}> has been scheduled to lock at <t:${lockTime}:F> (<t:${lockTime}:R>) and will be unlocked at <t:${unlockTime}:F> (<t:${unlockTime}:R>)`,
+					});
 				}
 				break;
 			}


### PR DESCRIPTION
Refines the user feedback for immediate and scheduled lockdowns. Now, the reply clearly distinguishes between channels locked immediately and those scheduled to be locked, improving clarity for moderators.