### PR TITLE
Add immediate lock confirmation message to Lockdown

### DIFF
--- a/src/commands/moderation/Lockdown.ts
+++ b/src/commands/moderation/Lockdown.ts
@@ -237,6 +237,7 @@ export default class LockdownCommand extends BaseCommand {
           },
           { upsert: true }
         );
+        
         if (lockTime === now) {
           let lockMessage: string;
           if (mode === "exam") {
@@ -301,9 +302,12 @@ export default class LockdownCommand extends BaseCommand {
           );
 
           await interaction.editReply({
+            content: `<#${channel.id}> has been locked and will be unlocked at <t:${unlockTime}:F> (<t:${unlockTime}:R>)`,
+          });
+        } else {
+          await interaction.editReply({
             content: `<#${channel.id}> will be locked at <t:${lockTime}:F> (<t:${lockTime}:R>) and will be unlocked at <t:${unlockTime}:F> (<t:${unlockTime}:R>)`,
           });
-          break;
         }
         break;
       }


### PR DESCRIPTION
When a channel is locked immediately, the bot now sends a confirmation message indicating the channel is locked and when it will be unlocked. This improves user feedback for instant lockdown actions.