### PR TITLE
Add lockdown confirmation message & update exam mode banner

### DIFF
--- a/src/commands/moderation/Lockdown.ts
+++ b/src/commands/moderation/Lockdown.ts
@@ -237,6 +237,7 @@ export default class LockdownCommand extends BaseCommand {
           },
           { upsert: true }
         );
+        
         if (lockTime === now) {
           let lockMessage: string;
           if (mode === "exam") {
@@ -301,9 +302,12 @@ export default class LockdownCommand extends BaseCommand {
           );
 
           await interaction.editReply({
+            content: `<#${channel.id}> has been locked and will be unlocked at <t:${unlockTime}:F> (<t:${unlockTime}:R>)`,
+          });
+        } else {
+          await interaction.editReply({
             content: `<#${channel.id}> will be locked at <t:${lockTime}:F> (<t:${lockTime}:R>) and will be unlocked at <t:${unlockTime}:F> (<t:${unlockTime}:R>)`,
           });
-          break;
         }
         break;
       }

--- a/src/commands/moderation/Lockdown.ts
+++ b/src/commands/moderation/Lockdown.ts
@@ -242,7 +242,7 @@ export default class LockdownCommand extends BaseCommand {
           let lockMessage: string;
           if (mode === "exam") {
             lockMessage =
-              "https://raw.githubusercontent.com/Juzcallmekaushik/r-igcse-bot/refs/heads/assets/r-igcse_locked_banner_gif_1_1.gif";
+              "https://github.com/Sachin-dot-py/r-igcse-bot/blob/assets/r-igcse-locked-gif.gif?raw=true";
           } else {
             lockMessage = "**Channel Locked !!**";
           }


### PR DESCRIPTION
When a channel is locked immediately, the bot now sends a confirmation message indicating that the channel is locked and when it will be unlocked. Replaced the old lockdown banner image URL with a new GitHub-hosted image for exam mode in the Lockdown command.